### PR TITLE
Fixes #15: Long Program Name

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,10 @@ WakaTime progress visualizer
 
 import re
 import os
+import sys
 import base64
 import datetime
 import requests
-import sys
 from github import Github, GithubException
 
 START_COMMENT = '<!--START_SECTION:waka-->'
@@ -21,10 +21,10 @@ show_title = os.getenv("INPUT_SHOW_TITLE")
 
 
 def this_week() -> str:
-    '''Returns a week's streak'''
+    '''Returns a week streak'''
     week_end = datetime.datetime.today() - datetime.timedelta(days=1)
     week_start = week_end - datetime.timedelta(days=7)
-    print("Week's header Created")
+    print("Week header created")
     return f"Week: {week_start.strftime('%d %B, %Y')} - {week_end.strftime('%d %B, %Y')}"
 
 
@@ -44,19 +44,18 @@ def get_stats() -> str:
     try:
         lang_data = data['data']['languages']
     except KeyError:
-        print("Please Add your Wakatime API Key to the Repository Secrets")
+        print("Please Add your WakaTime API Key to the Repository Secrets")
         sys.exit(1)
 
     data_list = []
-    lang_data = data['data']['languages']
     pad = len(max([l['name'] for l in lang_data[:5]], key=len))
-    for l in lang_data[:5]:
-        ln = len(l['name'])
-        ln_text = len(l['text'])
-        # to provide a neat finish.
-        fmt_percent = format(l['percent'], '0.2f').zfill(5)
+    for lang in lang_data[:5]:
+        lth = len(lang['name'])
+        ln_text = len(lang['text'])
+        # following line provides a neat finish
+        fmt_percent = format(lang['percent'], '0.2f').zfill(5)
         data_list.append(
-            f"{l['name']}{' '*(pad + 3 - ln)}{l['text']}{' '*(16-ln_text)}{make_graph(l['percent'])}   {fmt_percent} %")
+            f"{lang['name']}{' '*(pad + 3 - lth)}{lang['text']}{' '*(16 - ln_text)}{make_graph(lang['percent'])}   {fmt_percent} %")
     print("Graph Generated")
     data = ' \n'.join(data_list)
     if show_title == 'true':
@@ -91,5 +90,5 @@ if __name__ == '__main__':
     rdmd = decode_readme(contents.content)
     new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
     if new_readme != rdmd:
-        repo.update_file(path=contents.path, message='Updated with Dev Metrics', content=new_readme, sha=contents.sha, branch='master')
-        
+        repo.update_file(path=contents.path, message='Updated with Dev Metrics',
+                         content=new_readme, sha=contents.sha, branch='master')


### PR DESCRIPTION
- This is a hot fix for long program name error.
- Finds the length of maximum name and pads 3 spaces after it. (Yea, I know it's not efficient, will be working on it)

@guilyx can you please test and report the status whenever feasible.

cc: @athul