### PR TITLE
Add flag to specify a commit message of user's choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,16 @@ Markdown    52 mins             █░░░░░░░░░░░░░░░
 Docker      16 mins             ░░░░░░░░░░░░░░░░░░░░░░░░░   02.32 % 
 YAML        7 mins              ░░░░░░░░░░░░░░░░░░░░░░░░░   01.07 %
 ```
+
+2. You can specify a commit message to overrdie the default _"Updated the Graph with new Metrics"_. Here is how you do it
+
+```yml
+- uses: athul/waka-readme@master
+        with:
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          USERNAME: <username>
+          COMMIT_MESSAGE: Updated the Readme
+```
+
+If no commit message is specified in the `yml` file, it defaults to _"Updated the Graph with new Metrics"_

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     description: "Displays the week number and days in Readme as title"
     default: false
     required: false
+    
+  COMMIT_MESSAGE:
+    description: "Add a commit message of your choice"
+    default: "Updated the Graph with new Metrics"
+    required: false
 
 
 runs:

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ user = os.getenv('INPUT_USERNAME')
 waka_key = os.getenv('INPUT_WAKATIME_API_KEY')
 ghtoken = os.getenv('INPUT_GH_TOKEN')
 show_title = os.getenv("INPUT_SHOW_TITLE")
+commit_message = os.getenv("INPUT_COMMIT_MESSAGE")
 
 
 def this_week() -> str:
@@ -93,5 +94,5 @@ if __name__ == '__main__':
     rdmd = decode_readme(contents.content)
     new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
     if new_readme != rdmd:
-        repo.update_file(path=contents.path, message='Updated with Dev Metrics',
+        repo.update_file(path=contents.path, message=commit_message,
                          content=new_readme, sha=contents.sha, branch='master')


### PR DESCRIPTION
Fixes #24 

You can specify a commit message to overrdie the default _"Updated the Graph with new Metrics"_. Here is how you do it

```yml
- uses: athul/waka-readme@master
        with:
          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
          GH_TOKEN: ${{ secrets.GH_TOKEN }}
          USERNAME: <username>
          COMMIT_MESSAGE: Updated the Readme
```

If no commit message is specified in the `yml` file, it defaults to _"Updated the Graph with new Metrics"_