### PR TITLE
Insert space at the end of each line for text centering

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,9 +59,9 @@ def get_stats() -> str:
         # following line provides a neat finish
         fmt_percent = format(lang['percent'], '0.2f').zfill(5)
         data_list.append(
-            f"{lang['name']}{' '*(pad + 3 - lth)}{lang['text']}{' '*(16 - ln_text)}{make_graph(lang['percent'])}   {fmt_percent} %")
+            f"{lang['name']}{' '*(pad + 3 - lth)}{lang['text']}{' '*(16 - ln_text)}{make_graph(lang['percent'])}   {fmt_percent} % ")
     print("Graph Generated")
-    data = ' \n'.join(data_list)
+    data = '\n'.join(data_list)
     if show_title == 'true':
         print("Stats with Weeks in Title Generated")
         return '```text\n'+this_week()+'\n\n'+data+'\n```'


### PR DESCRIPTION
There was a problem with the text when centering.

<div align=center>

```txt
Go         23 hrs 59 mins  █████████████████████░░░░   84.67 % 
Markdown   1 hr 19 mins    █░░░░░░░░░░░░░░░░░░░░░░░░   04.65 % 
Python     53 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   03.12 % 
C          46 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   02.71 % 
C#         36 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   02.16 %
```

</div>

So, I put a space at the end of each line to align the text.

<div align=center>

```txt
Go         23 hrs 59 mins  █████████████████████░░░░   84.67 % 
Markdown   1 hr 19 mins    █░░░░░░░░░░░░░░░░░░░░░░░░   04.65 % 
Python     53 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   03.12 % 
C          46 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   02.71 % 
C#         36 mins         ░░░░░░░░░░░░░░░░░░░░░░░░░   02.16 % 
```

</div>