### PR TITLE
feat: Added ability to use a custom readme location

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ jobs:
    Other        ██▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   05.87 %
    ```
 
+8. If your readme file is symlinked or is in another location, you can point to it by adding `README_PATH: <your path here>` (by default it will be the readme in the root directory) in your workflow file like so:
+
+  ```yml
+      - uses: athul/waka-readme@master
+            with:
+              WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+              README_PATH: 'profile-readme/README.md'
+  ```
+
 > You can find all the options in [action.yml](action.yml) and a sample workflow [here](https://github.com/athul/athul/blob/master/.github/workflows/update-readme.yml).
 >
 > Tip 💡: Add `on: workflow_dispatch:` to enable manual runs. [See](https://github.com/joe733/joe733/blob/master/.github/workflows/waka.yml#L4).

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,19 @@ inputs:
     default: "false"
     required: false
 
+  # location configuration
+
+  README_PATH:
+    description: "Path to the README file"
+    default: ""
+    required: false
+    
+  REPO_BRANCH:
+    description: "Repository branch to use"
+    default: ""
+    required: false
+  
+
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -60,11 +60,6 @@ inputs:
     description: "Path to the README file"
     default: ""
     required: false
-    
-  REPO_BRANCH:
-    description: "Repository branch to use"
-    default: ""
-    required: false
   
 
 runs:

--- a/main.py
+++ b/main.py
@@ -323,7 +323,12 @@ def genesis() -> None:
     logger.debug('Conneting to GitHub')
     gh_connect = Github(wk_i.gh_token)
     gh_repo = gh_connect.get_repo(wk_i.repository)
-    readme_file = gh_repo.get_readme()
+    # location of readme file = profile-readme/README.md
+    readme_file = gh_repo.get_contents(
+        path='profile-readme/README.md',
+        ref=wk_i.branch
+    )
+    logger.debug('Done')
     logger.debug('Decoding readme contents')
     readme_contents = str(readme_file.decoded_content, encoding='utf-8')
     if new_content := churn(readme_contents):

--- a/main.py
+++ b/main.py
@@ -91,7 +91,6 @@ class WakaInput:
         self.show_time: str | bool = os.getenv("INPUT_SHOW_TIME")
         self.show_total_time: str | bool = os.getenv("INPUT_SHOW_TOTAL")
         self.readme_path: str = os.getenv("INPUT_README_PATH")
-        self.repo_branch: str = os.getenv("INPUT_REPO_BRANCH")
 
     def validate_input(self) -> bool:
         """
@@ -325,12 +324,12 @@ def genesis() -> None:
     logger.debug('Conneting to GitHub')
     gh_connect = Github(wk_i.gh_token)
     gh_repo = gh_connect.get_repo(wk_i.repository)
-    if not (wk_i.readme_path or wk_i.repo_branch):
+    if not (wk_i.readme_path):
         readme_file = gh_repo.get_readme()
     else: 
         readme_file = gh_repo.get_contents(
             path=wk_i.readme_path,
-            ref=wk_i.repo_branch
+            ref='main'
         )
     logger.debug('Done')
     logger.debug('Decoding readme contents')

--- a/main.py
+++ b/main.py
@@ -90,6 +90,8 @@ class WakaInput:
         self.time_range: str = os.getenv("INPUT_TIME_RANGE")
         self.show_time: str | bool = os.getenv("INPUT_SHOW_TIME")
         self.show_total_time: str | bool = os.getenv("INPUT_SHOW_TOTAL")
+        self.readme_path: str = os.getenv("INPUT_README_PATH")
+        self.repo_branch: str = os.getenv("INPUT_REPO_BRANCH")
 
     def validate_input(self) -> bool:
         """
@@ -323,11 +325,13 @@ def genesis() -> None:
     logger.debug('Conneting to GitHub')
     gh_connect = Github(wk_i.gh_token)
     gh_repo = gh_connect.get_repo(wk_i.repository)
-    # location of readme file = profile-readme/README.md
-    readme_file = gh_repo.get_contents(
-        path='profile-readme/README.md',
-        ref='main'
-    )
+    if not (wk_i.readme_path or wk_i.repo_branch):
+        readme_file = gh_repo.get_readme()
+    else: 
+        readme_file = gh_repo.get_contents(
+            path=wk_i.readme_path,
+            ref=wk_i.repo_branch
+        )
     logger.debug('Done')
     logger.debug('Decoding readme contents')
     readme_contents = str(readme_file.decoded_content, encoding='utf-8')

--- a/main.py
+++ b/main.py
@@ -326,7 +326,7 @@ def genesis() -> None:
     # location of readme file = profile-readme/README.md
     readme_file = gh_repo.get_contents(
         path='profile-readme/README.md',
-        ref=wk_i.branch
+        ref='main'
     )
     logger.debug('Done')
     logger.debug('Decoding readme contents')


### PR DESCRIPTION
### PR Information
This PR adds the ability to use a custom readme location for those people that symlinks their readme file to another location such as myself (see screenshot).
![brave_ZhTTNz8nGl](https://user-images.githubusercontent.com/53419401/177078510-b60b1723-d306-420f-9470-b5c5e363e94b.png)

### Why?
The function `gh_repo.get_readme()` only targets the symlink, resulting the workflow being unable to add wakatime statistics resulting in an error.

### Things I could've done
I could entirely omit the if statement and set the default variable for it to be `README.md`, but I don't know if that will work for people with lowercase `readme.md`'s potentially breaking it and that's why I used an if statement.

### Checklist/Tests
- [x] I made sure it ran successfully.
- [x] I made sure it worked with the variable set in place.
- [x] I made sure it worked even without the variable set in place.
- [x] I updated the documentation.

Let me know if there's anything else :)