### PR TITLE
Fix: resolve f-string syntax error in _extract_ignored_languages

### DIFF
--- a/main.py
+++ b/main.py
@@ -287,7 +287,7 @@ def _extract_ignored_languages():
             temp = igl.lstrip('"').lstrip("'")
             continue
         if igl.endswith(('"', "'")):
-            igl = f"{temp} {igl.rstrip('"').rstrip("'")}"
+            igl = temp + " " + igl.rstrip('"\'')
             temp = ""
         yield igl
 


### PR DESCRIPTION
- Replace problematic f-string with backslash escapes
- Use string concatenation instead of f-string for quote stripping
- Improve code readability and maintainability
- Fix line 290 syntax issue that prevented proper parsing

The f-string expression part cannot include backslashes, so now
the more straightforward approach with string concatenation and rstrip()
to handle both single and double quotes is used.