### PR TITLE
fix: extend prefix length to prevent layout mismatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ $ podman-compose -p waka-readme -f ./docker-compose.yml down
    $ python -m venv .venv
    $ . ./.venv/bin/activate
    $ python -m pip install .
-   # ... install decencies ...
+   # ... install dependencies ...
    ```
 
    to activate virtual environment & install dependencies.

--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ class WakaInput:
     """WakaReadme Input Env Variables."""
 
     # constants
-    prefix_length: int = 16
+    prefix_length: int = 22
     graph_length: int = 25
 
     # mapped environment variables
@@ -345,9 +345,10 @@ def prep_content(stats: dict[str, Any], /):
         lang_time = str(lang["text"]) if wk_i.show_time else ""
         lang_ratio = float(lang["percent"])
         lang_bar = make_graph(wk_i.block_style, lang_ratio, wk_i.graph_length, lang_name)
+        prefix_length = wk_i.prefix_length
         contents += (
             f"{lang_name.ljust(pad_len)}   "
-            + f"{lang_time: <16}{lang_bar}   "
+            + f"{lang_time: <{prefix_length}}{lang_bar}   "
             + f"{lang_ratio:.2f}".zfill(5)
             + " %\n"
         )


### PR DESCRIPTION
<img width="772" height="183" alt="image" src="https://github.com/user-attachments/assets/83f380ba-3bd2-4df8-a648-1b7a10f99a4e" />


Really long timings can cause overflow (it's not common for some wakatime devs to have been working for tens of thousands of hours!)

<img width="493" height="254" alt="image" src="https://github.com/user-attachments/assets/fce5d49f-7a37-4fff-a9cf-4d16604f36c0" />

Not a permanent solution, but (hopefully) no one's programming for a million hours :)